### PR TITLE
Replaced deprecated use of .error with .fail

### DIFF
--- a/assets/js/jquery.popup.js
+++ b/assets/js/jquery.popup.js
@@ -210,7 +210,7 @@
 							success : function(data){
 								callback.call(this, data);
 							},
-							error : function(data){
+							fail : function(data){
 								p.o.error.call(p, content, 'ajax');
 							}
 						});


### PR DESCRIPTION
Since jQuery 1.8 ajax.error() has been deprecated, but since 3.0 it's been removed. .fail() is the replacement function. This change makes the switch from .error() to .fail().
